### PR TITLE
jsx syntax

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,10 @@ import React from 'react';
 
 function App() {
   return (
-    <div><h1>Hello, world!</h1></div>
+    <React.Fragment>
+      <label htmlFor="bar">Bar!!!</label>
+      <input type="text" onChange={() => {console.log("I am clicked")}} />
+    </React.Fragment>
   );
 }
 


### PR DESCRIPTION
- `return`で返すRectComponentは一つのHTML要素を返すようにする
- div要素で囲って複数のHTML要素をラップするようにする
- クライアントでHTMLツリーを見たときにdiv要素が生成されてしまうのを防ぐには、divの代わりに`React.Fragment`タグを使用すると、余計なdivタグが生成されない